### PR TITLE
Add ingots-related commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 # Project-specific
 # breakdown_tmp/ holds breakdown txt files before uploading to discord.
 breakdown_tmp/
+# Credentials file for Google Sheets API
+credentials.json
+service.json

--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ Main dependencies:
 *  python3 pip (`sudo apt-get install python3-pip`)
 *  The Rapptz/discord.py library (`python3 -m pip install -U discord.py`)
 *  Parameterized for testing (`python3 -m pip install parameterized`)
+*  Libraries for connecting to Google Sheets API (`pip install --upgrade
+   google-api-python-client google-auth-httplib2 google-auth-oauthlib`)
+
 
 Secrets & tokens are written manually to ".env" in the base app directory.
 These are written as key:value pairs separated by "=". Required secrets:
 
+*  SHEETID: Unique ID for sheet to connect to.
 *  GUILDID: The integer of the Discord server the bot will join.
 *  BOT_TOKEN: The unique token for your application bot from the Discord
 Developer Portal.

--- a/main.py
+++ b/main.py
@@ -9,11 +9,19 @@ from discord import app_commands
 import requests
 from common import point_values
 
+from google.oauth2 import service_account
+from googleapiclient.discovery import build, Resource
+from googleapiclient.errors import HttpError
+
 
 # Don't care about line length for URLs & constants.
 # pylint: disable=line-too-long
 HISCORES_PLAYER_URL = 'https://secure.runescape.com/m=hiscore_oldschool/index_lite.ws?player={player}'
 LEVEL_99_EXPERIENCE = 13034431
+
+SHEETS_SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
+# Skip header in read.
+SHEET_RANGE = 'ClanIngots!A2:B'
 # pylint: enable=line-too-long
 
 
@@ -29,6 +37,9 @@ def read_dotenv(path: str) -> Dict[str, str]:
 
 
 def validate_initial_config(config: Dict[str, str]) -> bool:
+    if config.get('SHEETID') is None:
+        print('validation failed; SHEETID required but not present in env')
+        return False
     if config.get('GUILDID') is None:
         print('validation failed; GUILDID required but not present in env')
         return False
@@ -106,9 +117,14 @@ class DiscordClient(discord.Client):
         print('------')
 
 
+# TODO: Add tests using built command tree.
+
+
 def build_command_tree(
       client: discord.Client,
-      breakdown_dir_path: str) -> app_commands.CommandTree:
+      breakdown_dir_path: str,
+      sheets_client: Resource,
+      sheet_id: str) -> app_commands.CommandTree:
     """Build slashcommand handlers into CommandTree.
 
     Discord.py's CommandTree object is difficult to interact with. The
@@ -184,6 +200,143 @@ def build_command_tree(
             discord_file = discord.File(f, filename='breakdown.txt')
             await interaction.response.send_message(
                 message, file=discord_file)
+
+
+    # TODO: Move ingot implementations & helpers into their own module.
+
+
+    @tree.command()
+    @app_commands.describe(
+        player='Runescape username to view ingot count for.')
+    async def ingots(interaction: discord.Interaction, player: str):
+        """View ingots for a Runescape playername."""
+        result = {}
+
+        try:
+            result = sheets_client.spreadsheets().values().get(
+                spreadsheetId=sheet_id, range=SHEET_RANGE).execute()
+        except HttpError as e:
+            await interaction.response.send_message(
+                f'Encountered error reading from sheets: {e}')
+            return
+
+        values = result.get('values', [])
+
+        # Response is a list of lists, all of which have 2
+        # entries: ['username', count]. Transform that into
+        # a dictionary.
+        ingots_by_player = {}
+        for i in values:
+            ingots_by_player[i[0]] = i[1]
+
+        ingots = ingots_by_player.get(player, 0)
+        # TODO: Include ingot emoji in response.
+        await interaction.response.send_message(
+            f'{player} has {ingots} ingots')
+
+
+    @tree.command()
+    @app_commands.describe(
+        player='Runescape username to add ingots to.',
+        ingots='Number of ingots to add.')
+    async def addingots(
+        interaction: discord.Interaction, player: str, ingots: int):
+        """Add ingots to a Runescape alias."""
+        result = {}
+
+        try:
+            result = sheets_client.spreadsheets().values().get(
+                spreadsheetId=sheet_id, range=SHEET_RANGE).execute()
+        except HttpError as e:
+            await interaction.response.send_message(
+                f'Encountered error reading from sheets: {e}')
+            return
+
+        values = result.get('values', [])
+
+        # Start at 2 since we skip header
+        rowIndex = 2
+        found = False
+        newValue = 0
+        for i in values:
+            if i[0] == player:
+                found = True
+                newValue = int(i[1]) + ingots
+                break
+            rowIndex += 1
+
+        if not found:
+            await interaction.response.send_message(
+                f'{player} wasn\'t found.')
+            return
+
+        range = f'ClanIngots!B{rowIndex}:B{rowIndex}'
+        body = {
+            'values': [[newValue]]
+        }
+
+        try:
+            _ = sheets_client.spreadsheets().values().update(
+                spreadsheetId=sheet_id, range=range,
+                valueInputOption="RAW", body=body).execute()
+        except HttpError as e:
+            await interaction.response.send_message(
+                f'Encountered error writing to sheets: {e}')
+            return
+
+        await interaction.response.send_message(
+            f'Added {ingots} ingots to {player}')
+
+
+    @tree.command()
+    @app_commands.describe(
+        player='Runescape username to set ingots for.',
+        ingots='New number of ingots for player.')
+    async def updateingots(
+        interaction: discord.Interaction, player: str, ingots: int):
+        """Set ingots for a Runescape alias."""
+        result = {}
+
+        try:
+            result = sheets_client.spreadsheets().values().get(
+                spreadsheetId=sheet_id, range=SHEET_RANGE).execute()
+        except HttpError as e:
+            await interaction.response.send_message(
+                f'Encountered error reading from sheets: {e}')
+            return
+
+        values = result.get('values', [])
+
+        # Start at 2 since we skip header
+        rowIndex = 2
+        found = False
+        for i in values:
+            if i[0] == player:
+                found = True
+                break
+            rowIndex += 1
+
+        if not found:
+            await interaction.response.send_message(
+                f'{player} wasn\'t found.')
+            return
+
+        range = f'ClanIngots!B{rowIndex}:B{rowIndex}'
+        body = {
+            'values': [[ingots]]
+        }
+
+        try:
+            _ = sheets_client.spreadsheets().values().update(
+                spreadsheetId=sheet_id, range=range,
+                valueInputOption="RAW", body=body).execute()
+        except HttpError as e:
+            await interaction.response.send_message(
+                f'Encountered error writing to sheets: {e}')
+            return
+
+        await interaction.response.send_message(
+            f'Set ingot count to {ingots} for {player}')
 
 
     return tree
@@ -335,7 +488,11 @@ if __name__ == '__main__':
     guild = discord.Object(id=init_config.get('GUILDID'))
     client = DiscordClient(intents=intents, upload=args.upload_commands,
                            guild=guild)
-    tree = build_command_tree(client, args.breakdown_tmp_dir)
+
+    creds = service_account.Credentials.from_service_account_file('service.json', scopes=SHEETS_SCOPES)
+    service = build('sheets', 'v4', credentials=creds)
+
+    tree = build_command_tree(client, args.breakdown_tmp_dir, service, init_config.get('SHEETID'))
     client.tree = tree
 
     client.run(init_config.get('BOT_TOKEN'))


### PR DESCRIPTION
Adds commands for interacting with sheet backing ingots. Last remaining feature to implement is sheet-syncing with current discord server members after commands are run.

This doesn't add tests; I'll add those in a future PR. The do_$COMMAND pattern I did with score and breakdown feels smelly, and there must be a way to invoke the command from the built CommandTree object in tests. So I'd rather figure out how to do that and test these the elegant way.