### PR TITLE
Cleanup & polish

### DIFF
--- a/main.py
+++ b/main.py
@@ -500,7 +500,7 @@ async def updateingots(
 async def syncmembers(
     interaction: discord.Interaction, client: discord.Client,
     sheets_client: Resource, sheet_id: str):
-    guild = await client.fetch_guild(client.guild.id)
+#    guild = await client.fetch_guild(client.guild.id)
 
     mutator = interaction.user
     if isinstance(mutator, discord.User):
@@ -520,7 +520,8 @@ async def syncmembers(
     # First, read all members from Discord.
     members = []
     member_ids = []
-    async for member in guild.fetch_members(limit=None):
+    for member in client.get_guild(client.guild.id).members:
+#    async for member in guild.fetch_members(limit=None):
         members.append(member)
         member_ids.append(str(member.id))
 

--- a/main.py
+++ b/main.py
@@ -192,9 +192,9 @@ async def score(
 
     points = skill_points + activity_points
 
-    content=f"""{player} has {points}
-Points from skills: {skill_points}
-Points from minigames & bossing: {activity_points}"""
+    content=f"""{player} has {points:,}
+Points from skills: {skill_points:,}
+Points from minigames & bossing: {activity_points:,}"""
 
     # TODO: Include emoji icon from computeIconID in response.
     await interaction.response.send_message(content)
@@ -229,17 +229,17 @@ async def breakdown(interaction: discord.Interaction, player: str, breakdown_dir
     output = '---Points from Skills---\n'
     for i in point_values.skills():
         if points_by_skill.get(i, 0) > 0:
-            output += f'{i}: {points_by_skill.get(i)}\n'
-    output += (f'Total Skill Points: {skill_points} ' +
+            output += f'{i}: {points_by_skill.get(i):,}\n'
+    output += (f'Total Skill Points: {skill_points:,} ' +
         f'({round((skill_points / total_points) * 100, 2)}% of total)\n\n')
     output += '---Points from Minigames & Bossing---\n'
     for i in point_values.activities():
         if points_by_activity.get(i, 0) > 0:
-            output += f'{i}: {points_by_activity.get(i)}\n'
+            output += f'{i}: {points_by_activity.get(i):,}\n'
     output += (
         f'Total Minigame & Bossing Points: {activity_points} ' +
         f'({round((activity_points / total_points) * 100, 2)}% of total)\n\n')
-    output += f'Total Points: {total_points}\n'
+    output += f'Total Points: {total_points:,}\n'
 
     # Now we have all of the data that we need for a full point breakdown.
     # If we write a single file though, there is a potential race
@@ -290,7 +290,7 @@ async def ingots(
     ingots = ingots_by_player.get(player, 0)
     # TODO: Include ingot emoji in response.
     await interaction.response.send_message(
-        f'{player} has {ingots} ingots')
+        f'{player} has {ingots:,} ingots')
 
 
 # TODO: Ingots mutations should log the change to the
@@ -366,7 +366,7 @@ async def addingots(
         return
 
     await interaction.response.send_message(
-        f'Added {ingots} ingots to {player}')
+        f'Added {ingots:,} ingots to {player}')
 
     tz = timezone('EST')
     dt = datetime.now(tz)
@@ -449,7 +449,7 @@ async def updateingots(
         return
 
     await interaction.response.send_message(
-        f'Set ingot count to {ingots} for {player}')
+        f'Set ingot count to {ingots:,} for {player}')
 
     tz = timezone('EST')
     dt = datetime.now(tz)

--- a/main_test.py
+++ b/main_test.py
@@ -394,9 +394,9 @@ Total Points: 1,626
 
     def test_syncmembers(self):
         """Test that sheet can be updated to only members in Discord."""
-        mock_discord_client = AsyncMock()
+        mock_discord_client = MagicMock()
         mock_guild = MagicMock()
-        mock_discord_client.fetch_guild.return_value = mock_guild
+        mock_discord_client.get_guild.return_value = mock_guild
 
         member1 = MagicMock()
         member1.id = 1
@@ -413,22 +413,7 @@ Total Points: 1,626
         member3.name = "member3"
         member3.nick = "member3"
 
-        class AsyncMemberFetcher:
-            def __init__(self):
-                self.items = [member1, member2, member3]
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                try:
-                    return self.items.pop()
-                except IndexError:
-                    pass
-
-                raise StopAsyncIteration
-
-        mock_guild.fetch_members.return_value = AsyncMemberFetcher()
+        mock_guild.members = [member1, member2, member3]
 
         sheets_read_response = {'values': [
             ['member1', '200', '1'],

--- a/main_test.py
+++ b/main_test.py
@@ -166,7 +166,8 @@ class TestIronForgedBot(unittest.TestCase):
         response._content = bytes(hiscores_raw_response(), 'utf-8')
 
         with patch.object(requests, 'get', return_value=response):
-            self.loop.run_until_complete(main.score(self.mock_interaction, 'johnnycache'))
+            self.loop.run_until_complete(main.score(
+                self.mock_interaction, MagicMock(), 'johnnycache'))
 
         self.mock_interaction.response.send_message.assert_called_once_with(
             """johnnycache has 1,626
@@ -182,7 +183,7 @@ Points from minigames & bossing: 370""")
         with patch.object(requests, 'get', return_value=response):
             with patch('builtins.open', mo):
                 self.loop.run_until_complete(
-                    main.breakdown(self.mock_interaction, 'johnnycache', '/'))
+                    main.breakdown(self.mock_interaction, MagicMock(), 'johnnycache', '/'))
 
         self.mock_interaction.response.send_message.assert_called_once()
         mo().write.assert_called_once_with(
@@ -243,7 +244,7 @@ Total Points: 1,626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.ingots(
-            self.mock_interaction, 'johnnycache', sheets_client,
+            self.mock_interaction, MagicMock(), 'johnnycache', sheets_client,
             'bloop'))
 
         self.mock_interaction.response.send_message.assert_called_once_with(
@@ -260,7 +261,7 @@ Total Points: 1,626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.ingots(
-            self.mock_interaction, 'kennylogs', sheets_client,
+            self.mock_interaction, MagicMock(), 'kennylogs', sheets_client,
             'bloop'))
 
         self.mock_interaction.response.send_message.assert_called_once_with(
@@ -284,7 +285,7 @@ Total Points: 1,626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.addingots(
-            self.mock_interaction, 'johnnycache', 5000, sheets_client, ''))
+            self.mock_interaction, MagicMock(), 'johnnycache', 5000, sheets_client, ''))
 
         # Ideally we could read the written file to assert data present.
         # But this is sheets, not a database, so asserting the value in
@@ -309,7 +310,7 @@ Total Points: 1,626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.addingots(
-            self.mock_interaction, 'kennylogs', 5, sheets_client, ''))
+            self.mock_interaction, MagicMock(), 'kennylogs', 5, sheets_client, ''))
 
         self.mock_interaction.response.send_message.assert_called_once_with(
             'kennylogs wasn\'t found.')
@@ -324,7 +325,7 @@ Total Points: 1,626
         mock_interaction.response = AsyncMock()
 
         self.loop.run_until_complete(main.addingots(
-            mock_interaction, 'kennylogs', 5, Mock(), ''))
+            mock_interaction, MagicMock(), 'kennylogs', 5, Mock(), ''))
 
         mock_interaction.response.send_message.assert_called_once_with(
             'PERMISSION_DENIED: johnnycache is not in a leadership role.')
@@ -347,7 +348,7 @@ Total Points: 1,626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.updateingots(
-            self.mock_interaction, 'johnnycache', 4000, sheets_client, ''))
+            self.mock_interaction, MagicMock(), 'johnnycache', 4000, sheets_client, ''))
 
         self.assertEqual(
             http.request_sequence[1][2],
@@ -371,7 +372,7 @@ Total Points: 1,626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.updateingots(
-            self.mock_interaction, 'kennylogs', 400, sheets_client, ''))
+            self.mock_interaction, MagicMock(), 'kennylogs', 400, sheets_client, ''))
 
         self.mock_interaction.response.send_message.assert_called_once_with(
             'kennylogs wasn\'t found.')
@@ -386,7 +387,7 @@ Total Points: 1,626
         mock_interaction.response = AsyncMock()
 
         self.loop.run_until_complete(main.updateingots(
-            mock_interaction, 'kennylogs', 5, Mock(), ''))
+            mock_interaction, MagicMock(), 'kennylogs', 5, Mock(), ''))
 
         mock_interaction.response.send_message.assert_called_once_with(
             'PERMISSION_DENIED: johnnycache is not in a leadership role.')

--- a/main_test.py
+++ b/main_test.py
@@ -169,8 +169,8 @@ class TestIronForgedBot(unittest.TestCase):
             self.loop.run_until_complete(main.score(self.mock_interaction, 'johnnycache'))
 
         self.mock_interaction.response.send_message.assert_called_once_with(
-            """johnnycache has 1626
-Points from skills: 1256
+            """johnnycache has 1,626
+Points from skills: 1,256
 Points from minigames & bossing: 370""")
 
     def test_breakdown(self):
@@ -210,7 +210,7 @@ Farming: 39
 Runecraft: 76
 Hunter: 27
 Construction: 72
-Total Skill Points: 1256 (77.24% of total)
+Total Skill Points: 1,256 (77.24% of total)
 
 ---Points from Minigames & Bossing---
 Clue Scrolls (beginner): 38
@@ -229,13 +229,13 @@ Tempoross: 27
 Wintertodt: 40
 Total Minigame & Bossing Points: 370 (22.76% of total)
 
-Total Points: 1626
+Total Points: 1,626
 """)
 
     def test_ingots(self):
         """Test that ingots for given player are returned to user."""
         sheets_read_response = {'values': [
-            ['johnnycache', 200]]}
+            ['johnnycache', 2000]]}
 
         http = HttpMock(headers={'status': '200'})
         http.data = json.dumps(sheets_read_response)
@@ -247,7 +247,7 @@ Total Points: 1626
             'bloop'))
 
         self.mock_interaction.response.send_message.assert_called_once_with(
-            'johnnycache has 200 ingots')
+            'johnnycache has 2,000 ingots')
 
     def test_ingots_user_not_present(self):
         """Test that a missing player shows 0 ingots."""
@@ -284,19 +284,19 @@ Total Points: 1626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.addingots(
-            self.mock_interaction, 'johnnycache', 5, sheets_client, ''))
+            self.mock_interaction, 'johnnycache', 5000, sheets_client, ''))
 
         # Ideally we could read the written file to assert data present.
         # But this is sheets, not a database, so asserting the value in
         # the PUT request is close enough.
         self.assertEqual(
             http.request_sequence[1][2],
-            json.dumps({'values': [[205]]}))
+            json.dumps({'values': [[5200]]}))
 
         self.assertEqual(len(json.loads(http.request_sequence[3][2]).get('values', [])), 2)
 
         self.mock_interaction.response.send_message.assert_called_once_with(
-            'Added 5 ingots to johnnycache')
+            'Added 5,000 ingots to johnnycache')
 
     def test_addingots_player_not_found(self):
         """Test that a missing player is surfaced to caller."""
@@ -347,18 +347,18 @@ Total Points: 1626
             'sheets', 'v4', http=http, developerKey='bloop')
 
         self.loop.run_until_complete(main.updateingots(
-            self.mock_interaction, 'johnnycache', 400, sheets_client, ''))
+            self.mock_interaction, 'johnnycache', 4000, sheets_client, ''))
 
         self.assertEqual(
             http.request_sequence[1][2],
-            json.dumps({'values': [[400]]}))
+            json.dumps({'values': [[4000]]}))
 
         self.assertEqual(
             len(json.loads(http.request_sequence[3][2]).get('values', [])),
             2)
 
         self.mock_interaction.response.send_message.assert_called_once_with(
-            'Set ingot count to 400 for johnnycache')
+            'Set ingot count to 4,000 for johnnycache')
 
     def test_updateingots_player_not_found(self):
         """Test that a missing player is surfaced to caller."""


### PR DESCRIPTION
- Lots of pylint cleanup
- Prints integers with commas as separators. Doesn't factor in locale-aware separators, as existing bot behavior is commas. And also that would require finding the locale of the calling peer.
- Adds emojis to bot responses. These are rank-dependent for the score commands, and always "Ingot" for ingots commands.
- Some outbound call optimizing in /syncmembers.