### PR TITLE
Return syncmembers diffs to file and have it sent back

### DIFF
--- a/main.py
+++ b/main.py
@@ -619,7 +619,7 @@ Points from minigames & bossing: {activity_points:,}"""
 
 
     async def syncmembers(self, interaction: discord.Interaction):
-        output = '---Successfully synced members---\n'
+        output = ''
         mutator = interaction.user
         if isinstance(mutator, discord.User):
             await interaction.response.send_message(
@@ -645,7 +645,7 @@ Points from minigames & bossing: {activity_points:,}"""
                 members.append(member)
                 member_ids.append(member.id)
             else:
-                output += f'skipped user {member} because they don\'t have a \"Member\" role\n'
+                output += f'skipped user {member.name} because they don\'t have a "Member" role\n'
 
         # Then, get all current entries from storage.
         try:
@@ -665,11 +665,11 @@ Points from minigames & bossing: {activity_points:,}"""
             if member.id not in written_ids:
                 # Don't allow users without a nickname into storage.
                 if member.nick is None:
-                    output += f'skipped user {member} because they don\'t have a nickname in Discord\n'
+                    output += f'skipped user {member.name} because they don\'t have a nickname in Discord\n'
                     continue
                 new_members.append(Member(
                     id=int(member.id), runescape_name=member.nick.lower(), ingots=0))
-                output += f'added user {member} because they joined\n'
+                output += f'added user {member.nick} because they joined\n'
 
         try:
             self._storage_client.add_members(
@@ -684,7 +684,7 @@ Points from minigames & bossing: {activity_points:,}"""
         for existing_member in existing:
             if existing_member.id not in member_ids:
                 leaving_members.append(existing_member)
-                output += f'removed user {existing_member} because they left the server\n'
+                output += f'removed user {existing_member.runescape_name} because they left the server\n'
         try:
             self._storage_client.remove_members(
                 leaving_members, 'User Left Server')
@@ -713,6 +713,10 @@ Points from minigames & bossing: {activity_points:,}"""
                                 id=existing_member.id,
                                 runescape_name=member.nick.lower(),
                                 ingots=existing_member.ingots))
+                            
+        for changed_member in changed_members:
+            output += f'updated RSN for {changed_member.runescape_name}\n'
+
 
         try:
             self._storage_client.update_members(
@@ -722,14 +726,14 @@ Points from minigames & bossing: {activity_points:,}"""
                 f'Encountered error updating changed members: {e}')
             return
 
-        path = os.path.join(self._tmp_dir_path, 'log_syncmembers.txt')
+        path = os.path.join(self._tmp_dir_path, f'syncmembers_{mutator.nick}.txt')
         with open(path, 'w') as f:
             f.write(output)
 
         with open(path, 'rb') as f:
             discord_file = discord.File(f, filename='syncmembers.txt')
             await interaction.followup.send(
-                f'Successfully synced ingots storage with current members!',
+                'Successfully synced ingots storage with current members!',
                 file=discord_file)
 
 

--- a/main.py
+++ b/main.py
@@ -645,7 +645,7 @@ Points from minigames & bossing: {activity_points:,}"""
                 members.append(member)
                 member_ids.append(member.id)
             else:
-                output += f'skipped user {member} because they don\'t have a \"Member\" role'
+                output += f'skipped user {member} because they don\'t have a \"Member\" role\n'
 
         # Then, get all current entries from storage.
         try:

--- a/main_test.py
+++ b/main_test.py
@@ -286,10 +286,10 @@ Total Points: 1,626
 
         mock_storage.update_members.assert_called_once_with(
             [Member(id=123456, runescape_name='johnnycache', ingots=10000)],
-            'leader')
+            'leader', note='None')
 
         self.mock_interaction.followup.send.assert_called_once_with(
-            'Added 5,000 ingots to johnnycache. They now have 10,000 ingots')
+            'Added 5,000 ingots to johnnycache; reason: None. They now have 10,000 ingots')
 
     def test_addingots_player_not_found(self):
         """Test that a missing player is surfaced to caller."""
@@ -339,7 +339,7 @@ Total Points: 1,626
 
         mock_storage.update_members.assert_called_once_with(
             [Member(id=123456, runescape_name='johnnycache', ingots=10000)],
-            'leader')
+            'leader', note='None')
 
         mo().write.assert_called_once_with(
             """Added 5,000 ingots to johnnycache. They now have 10,000 ingots
@@ -363,7 +363,7 @@ kennylogsin not found in storage.""")
 
         mock_storage.update_members.assert_called_once_with(
             [Member(id=123456, runescape_name='johnnycache', ingots=10000)],
-            'leader')
+            'leader', note='None')
 
         mo().write.assert_called_once_with(
             """Added 5,000 ingots to johnnycache. They now have 10,000 ingots
@@ -412,10 +412,10 @@ skagul tosti not found in storage.""")
 
         mock_storage.update_members.assert_called_once_with([
             Member(id=123456, runescape_name='johnnycache', ingots=4000)],
-            'leader')
+            'leader', note='None')
 
         self.mock_interaction.followup.send.assert_called_once_with(
-            'Set ingot count to 4,000 for johnnycache')
+            'Set ingot count to 4,000 for johnnycache. Reason: None')
 
     def test_updateingots_player_not_found(self):
         """Test that a missing player is surfaced to caller."""
@@ -489,10 +489,14 @@ skagul tosti not found in storage.""")
             Member(id=2, runescape_name='Crimson chin', ingots=400),
             Member(id=4, runescape_name='member4', ingots=1000)]
 
+        mo = mock_open()
+
         commands = main.IronForgedCommands(
             MagicMock(), mock_discord_client, mock_storage, '')
-        self.loop.run_until_complete(commands.syncmembers(
-            self.mock_interaction))
+        
+        with patch('builtins.open', mo):
+            self.loop.run_until_complete(commands.syncmembers(
+                self.mock_interaction))
 
         mock_storage.add_members.assert_called_once_with([
             Member(id=3, runescape_name='member3', ingots=0)],
@@ -506,4 +510,6 @@ skagul tosti not found in storage.""")
             Member(id=1, runescape_name='johnnycache', ingots=200),
             Member(id=2, runescape_name='member2', ingots=400)],
             'Name Change')
+        
+        mo().write.assert_called_once_with("""added user member3 because they joined\nremoved user member4 because they left the server\nupdated RSN for johnnycache\nupdated RSN for member2\n""")
 


### PR DESCRIPTION
Here's a small addition to the syncmembers command that probably needs to be tested. Uses the same method as /breakdown where we create an output string and write it to a temp file to be displayed when the command completes. 

The syncmembers log should display:
- added user __ because they joined
- removed user __ because they left the server
- skipped user __ because they don't have a "Member" role
- skipped user __ because they don't have a nickname in Discord

as requested. 

The logic is already there so it was as simple as adding the strings within the loops and if/else statements.

Something I do have a concern about is for example, the remove_members() try/except statement fails on line 688, and how to handle the output string in such a case, but maybe it's fine??? (which is why this obviously would need some testing). 