### PR TITLE
Add Raffle Feature to Discord Bot

### DIFF
--- a/ironforgedbot/storage/sheets.py
+++ b/ironforgedbot/storage/sheets.py
@@ -6,7 +6,7 @@ from googleapiclient.discovery import build, Resource
 from googleapiclient.errors import HttpError
 import logging
 from pytz import timezone
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from ironforgedbot.storage.types import IngotsStorage, Member, StorageError
 
@@ -14,6 +14,8 @@ SHEETS_SCOPES = ['https://www.googleapis.com/auth/spreadsheets']
 # Skip header in read.
 SHEET_RANGE = 'ClanIngots!A2:B'
 SHEET_RANGE_WITH_DISCORD_IDS = 'ClanIngots!A2:C'
+RAFFLE_RANGE = 'ClanRaffle!A2'
+RAFFLE_TICKETS_RANGE = 'ClanRaffleTickets!A2:B'
 CHANGELOG_RANGE = 'ChangeLog!A2:F'
 
 
@@ -190,6 +192,178 @@ class SheetsStorage(metaclass=IngotsStorage):
             rows.append(['', '', ''])
         write_range = f'ClanIngots!A2:C{2 + len(existing)}'
         body = {'values': rows}
+
+        try:
+            _ = self._sheets_client.spreadsheets().values().update(
+                spreadsheetId=self._sheet_id, range=write_range,
+                valueInputOption="RAW", body=body).execute()
+        except HttpError as e:
+            raise StorageError(
+                f'Encountered error writing to sheets: {e}')
+
+        try:
+            self._log_change(changes)
+        except HttpError as e:
+            # Just swallow the error; the action is done & captured in version
+            # history at least.
+            pass
+
+    def start_raffle(self, attribution: str) -> None:
+        """Starts a raffle, enabling purchase of raffle tickets."""
+        tz = timezone('EST')
+        dt = self._clock.now(tz)
+        modification_timestamp = dt.strftime('%m/%d/%Y, %H:%M:%S')
+
+        result = {}
+        try:
+            result = self._sheets_client.spreadsheets().values().get(
+                spreadsheetId=self._sheet_id,
+                range=RAFFLE_RANGE).execute()
+        except HttpError as e:
+            raise StorageError(
+                f'Encountered error reading ClanRaffle from sheets: {e}')
+
+        values = result.get('values', [])
+        if values[0][0] != 'False':
+            raise StorageError('There is already a raffle ongoing')
+
+        body = {'values': [['True']]}
+
+        try:
+            _ = self._sheets_client.spreadsheets().values().update(
+                spreadsheetId=self._sheet_id, range=RAFFLE_RANGE,
+                valueInputOption="RAW", body=body).execute()
+        except HttpError as e:
+            raise StorageError(
+                f'Encountered error writing to sheets: {e}')
+
+        changes = [['', modification_timestamp, 'False', 'True', attribution, 'Started Raffle']]
+
+        try:
+            self._log_change(changes)
+        except HttpError as e:
+            # Just swallow the error; the action is done & captured in version
+            # history at least.
+            pass
+
+    def end_raffle(self, attribution: str) -> None:
+        """Marks a raffle as over, disallowing purchase of tickets."""
+        tz = timezone('EST')
+        dt = self._clock.now(tz)
+        modification_timestamp = dt.strftime('%m/%d/%Y, %H:%M:%S')
+
+        result = {}
+        try:
+            result = self._sheets_client.spreadsheets().values().get(
+                spreadsheetId=self._sheet_id,
+                range=RAFFLE_RANGE).execute()
+        except HttpError as e:
+            raise StorageError(
+                f'Encountered error reading ClanRaffle from sheets: {e}')
+
+        values = result.get('values', [])
+        if values[0][0] != 'True':
+            raise StorageError('There is no currently ongoing raffle')
+
+        body = {'values': [['False']]}
+
+        try:
+            _ = self._sheets_client.spreadsheets().values().update(
+                spreadsheetId=self._sheet_id, range=RAFFLE_RANGE,
+                valueInputOption="RAW", body=body).execute()
+        except HttpError as e:
+            raise StorageError(
+                f'Encountered error writing to sheets: {e}')
+
+        changes = [['', modification_timestamp, 'True', 'False', attribution, 'Ended Raffle']]
+
+        try:
+            self._log_change(changes)
+        except HttpError as e:
+            # Just swallow the error; the action is done & captured in version
+            # history at least.
+            pass
+
+    def read_raffle_tickets(self) -> Dict[int, int]:
+        """Reads number of tickets a user has for the current raffle."""
+        result = {}
+        try:
+            result = self._sheets_client.spreadsheets().values().get(
+                spreadsheetId=self._sheet_id,
+                range=RAFFLE_TICKETS_RANGE).execute()
+        except HttpError as e:
+            raise StorageError(
+                f'Encountered error reading ClanIngots from sheets: {e}')
+
+        # Unlike the ingots table, this is expected to get emptied.
+        # So we have to account for an empty response.
+        values = result.get('values', [])
+        tickets = {}
+        for value in values:
+            if len(value) >= 2:
+                tickets[int(value[0])] = int(value[1])
+
+        return tickets
+
+    def add_raffle_tickets(self, member_id: int, tickets: int) -> None:
+        """Add tickets to a given member."""
+        tz = timezone('EST')
+        dt = self._clock.now(tz)
+        modification_timestamp = dt.strftime('%m/%d/%Y, %H:%M:%S')
+        changes = []
+
+        # If user is in storage, add tickets. Otherwise, add them to storage.
+        new_count = tickets
+        existing_count = 0
+        current_tickets = self.read_raffle_tickets()
+        for id, current_count in current_tickets.items():
+            if id == member_id:
+                existing_count = current_count
+                new_count = current_count + tickets
+
+        current_tickets[member_id] = new_count
+        changes.append([member_id, modification_timestamp, existing_count, new_count, member_id, 'Bought raffle tickets'])
+
+        # Convert to list for write & sort for stability.
+        values = []
+        for id, current_count in current_tickets.items():
+            values.append([id, current_count])
+
+        values.sort(key=lambda x: x[0])
+
+        write_range = f'ClanRaffleTickets!A2:B{2 + len(values)}'
+        body = {'values': values}
+
+        try:
+            _ = self._sheets_client.spreadsheets().values().update(
+                spreadsheetId=self._sheet_id, range=write_range,
+                valueInputOption="RAW", body=body).execute()
+        except HttpError as e:
+            raise StorageError(
+                f'Encountered error writing to sheets: {e}')
+
+        try:
+            self._log_change(changes)
+        except HttpError as e:
+            # Just swallow the error; the action is done & captured in version
+            # history at least.
+            pass
+
+
+    def delete_raffle_tickets(self, attribution: str) -> None:
+        """Deletes all current raffle tickets. Called once when ending a raffle."""
+        tz = timezone('EST')
+        dt = self._clock.now(tz)
+        modification_timestamp = dt.strftime('%m/%d/%Y, %H:%M:%S')
+        changes = [['', modification_timestamp, '', '', attribution, 'Cleared all raffle tickets']]
+
+        values = []
+        current_tickets = self.read_raffle_tickets()
+        for _, _ in current_tickets.items():
+            values.append(['', ''])
+
+        write_range = f'ClanRaffleTickets!A2:B{2 + len(values)}'
+        body = {'values': values}
 
         try:
             _ = self._sheets_client.spreadsheets().values().update(

--- a/ironforgedbot/storage/sheets_test.py
+++ b/ironforgedbot/storage/sheets_test.py
@@ -154,3 +154,172 @@ class TestSheetsStorage(unittest.TestCase):
             http.request_sequence[2][2],
             json.dumps({'values': [
                 ['johnnycache', '08/26/2023, 18:33:20', str(johnnycache), 0, 'User Left Server', '']]}))
+
+    def test_start_raffle(self):
+        sheets_read_response = {'values': [['False']]}
+
+        http = HttpMockSequence([
+            ({'status': '200'}, json.dumps(sheets_read_response)),
+            ({'status': '200'}, json.dumps('')),
+            ({'status': '200'}, json.dumps(''))])
+
+        sheets_client = build('sheets', 'v4', http=http, developerKey='bloop')
+
+        mock_datetime = MagicMock()
+        mock_datetime.now.return_value = datetime.fromtimestamp(1693100000)
+
+        client = SheetsStorage(sheets_client, '', clock=mock_datetime)
+
+        client.start_raffle('johnnycache')
+
+        self.assertEqual(
+            http.request_sequence[1][2],
+            json.dumps({'values': [['True']]}))
+
+        self.assertEqual(
+            http.request_sequence[2][2],
+            json.dumps({'values': [
+                ['', '08/26/2023, 18:33:20', 'False', 'True', 'johnnycache', 'Started Raffle']]}))
+
+    def test_start_raffle_already_ongoing(self):
+        sheets_read_response = {'values': [['True']]}
+
+        http = HttpMock(headers={'status': '200'})
+        http.data = json.dumps(sheets_read_response)
+        sheets_client = build(
+            'sheets', 'v4', http=http, developerKey='bloop')
+
+        client = SheetsStorage(sheets_client, '')
+
+        with self.assertRaises(StorageError):
+            client.start_raffle('johnnycache')
+
+    def test_end_raffle(self):
+        sheets_read_response = {'values': [['True']]}
+
+        http = HttpMockSequence([
+            ({'status': '200'}, json.dumps(sheets_read_response)),
+            ({'status': '200'}, json.dumps('')),
+            ({'status': '200'}, json.dumps(''))])
+
+        sheets_client = build('sheets', 'v4', http=http, developerKey='bloop')
+
+        mock_datetime = MagicMock()
+        mock_datetime.now.return_value = datetime.fromtimestamp(1693100000)
+
+        client = SheetsStorage(sheets_client, '', clock=mock_datetime)
+
+        client.end_raffle('johnnycache')
+
+        self.assertEqual(
+            http.request_sequence[1][2],
+            json.dumps({'values': [['False']]}))
+
+        self.assertEqual(
+            http.request_sequence[2][2],
+            json.dumps({'values': [
+                ['', '08/26/2023, 18:33:20', 'True', 'False', 'johnnycache', 'Ended Raffle']]}))
+
+    def test_end_raffle_none_ongoing(self):
+        sheets_read_response = {'values': [['False']]}
+
+        http = HttpMock(headers={'status': '200'})
+        http.data = json.dumps(sheets_read_response)
+        sheets_client = build(
+            'sheets', 'v4', http=http, developerKey='bloop')
+
+        client = SheetsStorage(sheets_client, '')
+
+        with self.assertRaises(StorageError):
+            client.end_raffle('johnnycache')
+
+    def test_read_raffle_tickets(self):
+        sheets_read_response = {'values': [['12345', '20']]}
+
+        http = HttpMock(headers={'status': '200'})
+        http.data = json.dumps(sheets_read_response)
+        sheets_client = build(
+            'sheets', 'v4', http=http, developerKey='bloop')
+
+        client = SheetsStorage(sheets_client, '')
+
+        self.assertEqual(
+            {12345: 20}, client.read_raffle_tickets())
+
+    def test_add_raffle_tickets(self):
+        sheets_read_response = {'values': [['12345', '20']]}
+
+        http = HttpMockSequence([
+            ({'status': '200'}, json.dumps(sheets_read_response)),
+            ({'status': '200'}, json.dumps('')),
+            ({'status': '200'}, json.dumps(''))])
+
+        sheets_client = build('sheets', 'v4', http=http, developerKey='bloop')
+
+        mock_datetime = MagicMock()
+        mock_datetime.now.return_value = datetime.fromtimestamp(1693100000)
+
+        client = SheetsStorage(sheets_client, '', clock=mock_datetime)
+
+        client.add_raffle_tickets(12345, 5)
+
+        self.assertEqual(
+            http.request_sequence[1][2],
+            json.dumps({'values': [[12345, 25]]}))
+
+        self.assertEqual(
+            http.request_sequence[2][2],
+            json.dumps({'values': [
+                [12345, '08/26/2023, 18:33:20', 20, 25, 12345, 'Bought raffle tickets']]}))
+
+    def test_add_raffle_tickets_first_buy(self):
+        sheets_read_response = {'values': [[]]}
+
+        http = HttpMockSequence([
+            ({'status': '200'}, json.dumps(sheets_read_response)),
+            ({'status': '200'}, json.dumps('')),
+            ({'status': '200'}, json.dumps(''))])
+
+        sheets_client = build('sheets', 'v4', http=http, developerKey='bloop')
+
+        mock_datetime = MagicMock()
+        mock_datetime.now.return_value = datetime.fromtimestamp(1693100000)
+
+        client = SheetsStorage(sheets_client, '', clock=mock_datetime)
+
+        client.add_raffle_tickets(12345, 5)
+
+        self.assertEqual(
+            http.request_sequence[1][2],
+            json.dumps({'values': [[12345, 5]]}))
+
+        self.assertEqual(
+            http.request_sequence[2][2],
+            json.dumps({'values': [
+                [12345, '08/26/2023, 18:33:20', 0, 5, 12345, 'Bought raffle tickets']]}))
+
+    def test_delete_raffle_tickets(self):
+        sheets_read_response = {'values': [['12345', '20']]}
+
+        http = HttpMockSequence([
+            ({'status': '200'}, json.dumps(sheets_read_response)),
+            ({'status': '200'}, json.dumps('')),
+            ({'status': '200'}, json.dumps(''))])
+
+        sheets_client = build('sheets', 'v4', http=http, developerKey='bloop')
+
+        mock_datetime = MagicMock()
+        mock_datetime.now.return_value = datetime.fromtimestamp(1693100000)
+
+        client = SheetsStorage(sheets_client, '', clock=mock_datetime)
+
+        client.delete_raffle_tickets('johnnycache')
+
+        self.assertEqual(
+            http.request_sequence[1][2],
+            json.dumps({'values': [['', '']]}))
+
+        self.assertEqual(
+            http.request_sequence[2][2],
+            json.dumps({'values': [
+                ['', '08/26/2023, 18:33:20', '', '', 'johnnycache', 'Cleared all raffle tickets']]}))

--- a/ironforgedbot/storage/sheets_test.py
+++ b/ironforgedbot/storage/sheets_test.py
@@ -265,7 +265,7 @@ class TestSheetsStorage(unittest.TestCase):
 
         self.assertEqual(
             http.request_sequence[1][2],
-            json.dumps({'values': [[12345, 25]]}))
+            json.dumps({'values': [['12345', '25']]}))
 
         self.assertEqual(
             http.request_sequence[2][2],
@@ -291,7 +291,7 @@ class TestSheetsStorage(unittest.TestCase):
 
         self.assertEqual(
             http.request_sequence[1][2],
-            json.dumps({'values': [[12345, 5]]}))
+            json.dumps({'values': [['12345', '5']]}))
 
         self.assertEqual(
             http.request_sequence[2][2],

--- a/ironforgedbot/storage/types.py
+++ b/ironforgedbot/storage/types.py
@@ -61,6 +61,10 @@ class IngotsStorage(type):
         """Removes provided members from storage. Requires Member.id."""
 
     @abstractmethod
+    def read_raffle(self) -> bool:
+        """Reads if a raffle is currently ongoing."""
+
+    @abstractmethod
     def start_raffle(self, attribution: str) -> None:
         """Starts a raffle, enabling purchase of raffle tickets."""
 

--- a/ironforgedbot/storage/types.py
+++ b/ironforgedbot/storage/types.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 class StorageError(Exception):
     """Base exception raised for storage operations."""
@@ -25,6 +25,19 @@ class IngotsStorage(type):
     Operations are based on player runescape names, but these
     are malleable and will often change. Inversely, the Discord
     id never changes.
+
+    For raffles, a separate table controls the existence of a raffle.
+    Only one raffle can be ongoing at a time. For the table controlling
+    how many tickets a given member has, the effective schema is:
+    Discord ID (key), ticket count.
+
+    The ingots table acts as the RSN:ID mapping.
+
+    Implementation note: Ideally, ticket count would just be another
+    column on the existing ingots table, and we could cut out the
+    raffle functions from the interface. However, with sheets as the
+    primary storage system, that interface is clunky enough that it is
+    more difficult to update individual columns.
 """
 
     @abstractmethod
@@ -46,3 +59,32 @@ class IngotsStorage(type):
     @abstractmethod
     def remove_members(self, members: List[Member], attribution: str, note: str = '') -> None:
         """Removes provided members from storage. Requires Member.id."""
+
+    @abstractmethod
+    def start_raffle(self, attribution: str) -> None:
+        """Starts a raffle, enabling purchase of raffle tickets."""
+
+    @abstractmethod
+    def end_raffle(self, attribution: str) -> None:
+        """Marks a raffle as over, disallowing purchase of tickets."""
+
+    @abstractmethod
+    def read_raffle_tickets(self) -> Dict[int, int]:
+        """Reads number of tickets a user has for the current raffle.
+
+        Returns:
+            Dictionary of Discord ID:Number of tickets.
+        """
+
+    @abstractmethod
+    def add_raffle_tickets(self, member_id: int, tickets: int) -> None:
+        """Adds tickets to a given member.
+
+        Args:
+            member_id: Discord ID of user to add tickets to.
+            tickets: Number of tickets to add to this user.
+        """
+
+    @abstractmethod
+    def delete_raffle_tickets(self, attribution: str) -> None:
+        """Deletes all current raffle tickets. Called once when ending a raffle."""

--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ def compute_clan_icon(points: int):
 
 
 def check_role(member: discord.Member, checked_role: str) -> bool:
-    """Check if a member has a leadership role."""
+    """Check if a member has a given role."""
     roles = member.roles
     for role in roles:
         if role.name == checked_role:
@@ -716,7 +716,7 @@ Points from minigames & bossing: {activity_points:,}"""
                                 id=existing_member.id,
                                 runescape_name=member.nick.lower(),
                                 ingots=existing_member.ingots))
-                            
+
         for changed_member in changed_members:
             output += f'updated RSN for {changed_member.runescape_name}\n'
 


### PR DESCRIPTION
This adds the ability to hold raffles with ingots for the bot. Notable components:
- Expected new tables 'ClanRaffle' & 'ClanRaffleTickets' in database
- Has connectors for starting a raffle, ending a raffle, and choosing a winner by random chance
- Users can buy tickets only while a raffle is ongoing
- Users can see how many tickets they've bought

Bot expects tickets to cost 5k ingots each, and will payout half the pot in winnings.